### PR TITLE
Add Read the Docs configuration file for documentation builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,30 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  jobs:
+    post_create_environment:
+      # Install poetry
+      - pip install poetry
+    post_install:
+      # Install dependencies with poetry
+      - poetry install --with dev
+
+# Build documentation with MkDocs
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
## Summary
This PR adds a `.readthedocs.yaml` configuration file to enable automated documentation builds on Read the Docs platform.

## Key Changes
- Added Read the Docs v2 configuration file with:
  - Ubuntu 22.04 build environment with Python 3.12
  - Poetry dependency management setup
  - MkDocs as the documentation builder
  - Proper installation of project dependencies and dev tools

## Implementation Details
- Configured post-environment creation hook to install Poetry
- Set up post-install hook to install all dependencies (including dev) via Poetry
- Specified MkDocs configuration file location (`mkdocs.yml`)
- Declared pip-based Python package installation for reproducible builds
- Follows Read the Docs best practices for reproducible documentation builds

This enables the project's documentation to be automatically built and hosted on Read the Docs whenever changes are pushed to the repository.