### PR TITLE
Fix ReadTheDocs build by adding MkDocs dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,3 +28,4 @@ python:
   install:
     - method: pip
       path: .
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+# Documentation build requirements for ReadTheDocs
+mkdocs>=1.6.1,<2.0.0
+mkdocs-material>=9.7.1,<10.0.0
+mkdocstrings[python]>=1.0.2,<2.0.0
+mkdocs-gen-files>=0.6.0,<0.7.0
+mkdocs-literate-nav>=0.6.2,<0.7.0
+mkdocs-section-index>=0.3.10,<0.4.0


### PR DESCRIPTION
The build was failing because mkdocs-material and related plugins were not installed in the ReadTheDocs environment. Added a docs/requirements.txt file with all necessary MkDocs dependencies and updated .readthedocs.yaml to install them.

This resolves the error:
"cannot find module 'material.extensions.emoji' (No module named 'material')"